### PR TITLE
SFT-293 Move dashboard font loader to main.qml

### DIFF
--- a/src/Battery.qml
+++ b/src/Battery.qml
@@ -3,6 +3,7 @@ import QtGraphicalEffects 1.12
 
 Item {
     id: batteryComponent
+    property FontLoader batteryFont
     property real batteryPercentage
 
     Rectangle {
@@ -64,11 +65,6 @@ Item {
 
     }
 
-    FontLoader
-    {
-        id: dashBoardFont
-        source: "fonts/Oswald/Oswald-VariableFont_wght.ttf"
-    }
 
     Text
     {
@@ -78,7 +74,7 @@ Item {
         font {
             pointSize: batteryBorder.height * 0.6
             weight: Font.DemiBold
-            family: dashBoardFont.name
+            family: batteryFont.name
         }
         anchors {
             verticalCenter: batteryBorder.verticalCenter

--- a/src/main.qml
+++ b/src/main.qml
@@ -9,6 +9,12 @@ Window {
     visible: true
     title: qsTr("Helios Dashboard")
 
+    FontLoader
+    {
+        id: dashBoardFont
+        source: "fonts/Oswald/Oswald-VariableFont_wght.ttf"
+    }
+
     Rectangle {
         id: background
         anchors.fill: parent
@@ -49,7 +55,8 @@ Window {
             id: battery
             width: 260
             height: 53
-            batteryPercentage: slider.value
+            batteryFont: dashBoardFont
+            batteryPercentage: 0
 
             anchors {
                 horizontalCenter: background.horizontalCenter


### PR DESCRIPTION
Font loader now in main.qml. All QML objects can access this font
through the creation of a property. This has been done for Battery.qml