### PR TITLE
Updated READMe to include mac run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,49 @@ Cross compiling is the same as the above steps, with a few modifications:
 There must be a `config.ini` beside the execuable to run properly.
 An example can be found in `config.ini.example`, and any necessary settings can be updated.
 
+## **Mac Setup Instructions**
+
+1. Clone the repository to a location without spaces in the file path, such as the Desktop.
+    
+    **IMPORTANT: AVOID SPACES IN THE FILE PATH TO PREVENT ERRORS**
+    
+    ```bash
+    git clone <repository_url>
+    ```
+    
+2. Open [HeliosDashboard.pro](http://heliosdashboard.pro/) from the 'src' folder from cloned repo in QtCreator and click on "Configure project."
+3. Run the following command in the Qt Terminal:
+    
+    ```bash
+    ./HeliosDashboardSetup.sh
+    ```
+    
+
+### **Project Configuration**
+
+1. Navigate to the 'Projects' tab and configure the following steps:
+    - From the 'Build steps' section, choose "Create a custom build" and move the custom build step to be the first step in the build process.
+    - Set the **`Command`** line as follows:
+        - Find the installation location of Conan using **`which conan`** in the terminal.
+        - Enter the file path obtained from the terminal:
+            
+            ```bash
+            <fill this part in with the local path to>/conan
+            ```
+            
+        - Note: If a "conan not found" error or similar occurs in the console output after the build, manually select the Conan file by choosing "Select" at the end of the command field and selcting the file named "conan."
+    - Set the **`Arguments`** line as follows:
+        
+        ```jsx
+        install ../conanfile.txt --build=missing -s compiler=apple-clang -s compiler.version=11.0
+        ```
+        
+2. Attempt to build and run the project.
+    - If an "executable not found" error occurs, click on the project configuration button which allows you to select different run configurations.
+    
+    - Toggle between 'Debug' and 'Profile,' allowing Qt to index the project. After each toggle, return to the 'Run' menu and select "HeliosDashboard" as the run configuration. Give this a couple attempts and the run configuration for Helios should appear.
+    - Build and Run the project.
+
 ### Switching Modes
 
 There are three different modes for the dashboard: Display mode, Debug Display mode and race mode. The default mode is display mode.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/UCSolarCarTeam/Epsilon-Dashboard.png?columns=all)](https://waffle.io/UCSolarCarTeam/Epsilon-Dashboard?utm_source=badge)
-# Epsilon-Dashboard
+# Helios-Dashboard
 
 The Epsilon Dashboard displays information on the screens.
 
@@ -110,7 +110,7 @@ An example can be found in `config.ini.example`, and any necessary settings can 
         
 2. Attempt to build and run the project.
     - If an "executable not found" error occurs, click on the project configuration button which allows you to select different run configurations.
-    
+
     - Toggle between 'Debug' and 'Profile,' allowing Qt to index the project. After each toggle, return to the 'Run' menu and select "HeliosDashboard" as the run configuration. Give this a couple attempts and the run configuration for Helios should appear.
     - Build and Run the project.
 


### PR DESCRIPTION
Updated the readMe to now have configuration and run instructions for Silicon-based Macs. 

The remainder of READMe still needs to be updated for Helios. 